### PR TITLE
[Proposed change] Changed Google Search string in Browser arrays

### DIFF
--- a/hennessy_stable/Browser.apk/res/values/arrays.xml
+++ b/hennessy_stable/Browser.apk/res/values/arrays.xml
@@ -180,7 +180,7 @@
         <item>Google</item>
         <item>google.com</item>
         <item>http://www.google.com/favicon.ico</item>
-        <item>http://www.google.com/search?hl={language}&amp;ie={inputEncoding}&amp;source=android-browser&amp;q={searchTerms}</item>
+        <item>http://www.google.com/search?ie={inputEncoding}&amp;source=android-browser&amp;q={searchTerms}</item>
         <item>UTF-8</item>
         <item>http://api.bing.com/osjson.aspx?query={searchTerms}&amp;language={language}</item>
     </string-array>


### PR DESCRIPTION
It's simple and more effective let you understand this issue with screenshots...

**\- Changed search language in Google Search settings, spanish was selected**

![screenshot_2016-04-01-15-22-07_com android browser](https://cloud.githubusercontent.com/assets/16099943/14208306/0e76b59e-f81f-11e5-9824-66115faab68c.png)

![screenshot_2016-03-22-23-06-13_com android browser](https://cloud.githubusercontent.com/assets/16099943/13969856/72570f4c-f085-11e5-82fc-dba36d2de7a8.png)

**\- Searching "Manzana" that is Apple in english. And getting an english result instead of a spanish one**

![screenshot_2016-03-22-23-07-15_com android browser](https://cloud.githubusercontent.com/assets/16099943/13969861/76ce2a60-f085-11e5-984a-4c4c84a92aea.png)

**\- Chrome behaves in the correct way**

![screenshot_2016-03-22-23-11-12_com android chrome](https://cloud.githubusercontent.com/assets/16099943/13969864/7a11aa8a-f085-11e5-8d4d-9edf6c970d6f.png)

P.S. line 185 is ok? Because I don't have google suggestions...

If you change language in Search Settings in Google.com webpage usually doing a search should reflect and respect those changed settings and find results in the language you set. 
But with **hl={language}** (maybe other stuff after "http://www.google.com/search?q=" is also unnecessary?) in line 183 this won't happen and search results will be always in your phone language skipping/bypassing your Google.com Language Search Settings.
In Google Chrome it's all ok and languages settings are effective and working.

(Look at the screenshots: I set spanish language and I search "Manzana" - That is "Apple" in spanish and this give me an english based result despite I've changed search language settings. As you can see in Chrome the behavior is normal)
