### PR TITLE
[Proposed change] Changed google search string in Browser arrays

### DIFF
--- a/libra_stable/Browser.apk/res/values/arrays.xml
+++ b/libra_stable/Browser.apk/res/values/arrays.xml
@@ -180,7 +180,7 @@
         <item>Google</item>
         <item>google.com</item>
         <item>http://www.google.com/favicon.ico</item>
-        <item>http://www.google.com/search?hl={language}&amp;ie={inputEncoding}&amp;source=android-browser&amp;q={searchTerms}</item>
+        <item>http://www.google.com/search?ie={inputEncoding}&amp;source=android-browser&amp;q={searchTerms}</item>
         <item>UTF-8</item>
         <item>http://api.bing.com/osjson.aspx?query={searchTerms}&amp;language={language}</item>
     </string-array>


### PR DESCRIPTION
If you change language in search settings in google.com page usually do a search should reflect and respect those changed settings and find results in the language you want. But with hl={language} in line 183 this won't happen and searches will be always in your phone language skipping your google page search settings. In Google Chrome it's all ok and languages settings will be respected.

P.S. line 185 is ok?